### PR TITLE
handle auth URL already containing query part

### DIFF
--- a/src/pylti1p3/oidc_login.py
+++ b/src/pylti1p3/oidc_login.py
@@ -135,7 +135,10 @@ class OIDCLogin(t.Generic[REQ, TCONF, SES, COOK, RED]):
             # LTI message hint to identify LTI context within the platform
             auth_params["lti_message_hint"] = lti_message_hint
 
-        auth_login_return_url = auth_login_url + "?" + urlencode(auth_params)
+        if "?" in auth_login_url:
+            auth_login_return_url = auth_login_url + "&" + urlencode(auth_params)
+        else:
+            auth_login_return_url = auth_login_url + "?" + urlencode(auth_params)
         return auth_login_return_url
 
     def _prepare_redirect(self, launch_url: str) -> Redirect[RED]:


### PR DESCRIPTION
The code can generate invalid auth URLs (https://github.com/dmitry-viskov/pylti1.3/issues/136). This fixes it.