### PR TITLE
use partitioned cookie for state

### DIFF
--- a/src/pylti1p3/contrib/flask/cookie.py
+++ b/src/pylti1p3/contrib/flask/cookie.py
@@ -31,4 +31,5 @@ class FlaskCookieService(CookieService):
 
             if self._request.is_secure():
                 cookie_kwargs["samesite"] = "None"
+            cookie_kwargs["partitioned"] = True
             response.set_cookie(**cookie_kwargs)

--- a/src/pylti1p3/cookies_allowed_check.py
+++ b/src/pylti1p3/cookies_allowed_check.py
@@ -89,7 +89,7 @@ class CookiesAllowedCheckPage:
         function checkCookiesAllowed() {
             var cookie = "lti1p3_test_cookie=1; path=/";
             if (siteProtocol === 'https') {
-                cookie = cookie + '; SameSite=None; secure';
+                cookie = cookie + '; SameSite=None; secure; partitioned';
             }
             document.cookie = cookie;
             var res = document.cookie.indexOf("lti1p3_test_cookie") !== -1;


### PR DESCRIPTION
Browsers are starting to block access to cookies in IFRAMEs, unless they are flagged with a new Partitioned attribute.

I have added this for Flask and it's working in my application. It needs a new Werkzeug in order to be effective.

Further work is needed to support this in Django, if it's possible. I don't know Django so assistance is welcome. Hence I'm marking this as a draft.