### PR TITLE
Remove universal wheel building

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal=1
-
 [metadata]
 description-file = README.rst
 license_file = LICENSE


### PR DESCRIPTION
This is unnecessary - python 2 is no longer supported.