### PR TITLE
Fix tests

### DIFF
--- a/src/pylti1p3/contrib/django/oidc_login.py
+++ b/src/pylti1p3/contrib/django/oidc_login.py
@@ -1,6 +1,7 @@
 import typing as t
 from django.http import HttpResponse, HttpRequest  # type: ignore
 from django.shortcuts import render
+from django.template.exceptions import TemplateDoesNotExist
 from pylti1p3.oidc_login import OIDCLogin
 
 from .cookie import DjangoCookieService

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import django
+from django.conf import settings
+
+
+def pytest_configure():
+    settings.configure(
+        CACHES={
+            "default": {
+                "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            }
+        }
+    )

--- a/tests/test_deep_link.py
+++ b/tests/test_deep_link.py
@@ -6,6 +6,7 @@ from .flask_mixin import FlaskMixin
 
 class DeepLinkBase(TestLinkBase):
     # pylint: disable=abstract-method,no-member
+    __test__ = False
 
     iss = "http://imsglobal.org"
     jwt_canvas_keys = {
@@ -150,7 +151,8 @@ class DeepLinkBase(TestLinkBase):
             uuid_val="462a941bbf6a4356afa7"
         )
 
-        launch_request = self._get_request(login_request, login_response)
+        launch_request = self._get_request(login_request=login_request, login_response=login_response)
+
         validated_message_launch = self._launch(
             launch_request, tool_conf, force_validation=True
         )
@@ -184,8 +186,8 @@ class DeepLinkBase(TestLinkBase):
 
 
 class TestDjangoDeepLink(DjangoMixin, DeepLinkBase):
-    pass
+    __test__ = True
 
 
 class TestFlaskDeepLink(FlaskMixin, DeepLinkBase):
-    pass
+    __test__ = True

--- a/tests/test_privacy_launch.py
+++ b/tests/test_privacy_launch.py
@@ -4,6 +4,7 @@ from .flask_mixin import FlaskMixin
 
 
 class PrivacyLaunchBase(TestLinkBase):
+    __test__ = False
     # pylint: disable=abstract-method,no-member
 
     iss = "https://canvas.instructure.com"
@@ -130,7 +131,7 @@ class PrivacyLaunchBase(TestLinkBase):
 
     def test_privacy_launch_success(self):
         tool_conf, login_request, login_response = self._make_oidc_login()
-        launch_request = self._get_request(login_request, login_response)
+        launch_request = self._get_request(login_request=login_request, login_response=login_response)
         validated_message_launch = self._launch(
             launch_request, tool_conf, force_validation=True
         )
@@ -146,8 +147,8 @@ class PrivacyLaunchBase(TestLinkBase):
 
 
 class TestDjangoPrivacyLaunch(DjangoMixin, PrivacyLaunchBase):
-    pass
+    __test__ = True
 
 
 class TestFlaskPrivacyLaunch(FlaskMixin, PrivacyLaunchBase):
-    pass
+    __test__ = True

--- a/tests/test_resource_link.py
+++ b/tests/test_resource_link.py
@@ -7,6 +7,7 @@ from .flask_mixin import FlaskMixin
 
 
 class ResourceLinkBase(TestLinkBase):
+    __test__ = False
     # pylint: disable=abstract-method,no-member
 
     iss = "https://canvas.instructure.com"
@@ -192,7 +193,7 @@ class ResourceLinkBase(TestLinkBase):
             cache=cache,
         )
         launch_request = self._get_request(
-            login_request, login_response, request_is_secure=secure
+            login_request=login_request, login_response=login_response, request_is_secure=secure
         )
         message_launch_data = self._launch(launch_request, tool_conf, cache=cache)
         self.assertDictEqual(message_launch_data, self.expected_message_launch_data)
@@ -220,7 +221,7 @@ class ResourceLinkBase(TestLinkBase):
     def test_res_link_launch_invalid_public_key(self):
         tool_conf, login_request, login_response = self._make_oidc_login()
 
-        launch_request = self._get_request(login_request, login_response)
+        launch_request = self._get_request(login_request=login_request, login_response=login_response)
         with self.assertRaisesRegex(LtiException, "Invalid response"):
             self._launch(
                 launch_request, tool_conf, key_set_url_response="invalid_key_set"
@@ -233,13 +234,13 @@ class ResourceLinkBase(TestLinkBase):
         post_data.pop("state", None)
 
         launch_request = self._get_request(
-            login_request, login_response, post_data=post_data
+            login_request=login_request, login_response=login_response, post_data=post_data
         )
         with self.assertRaisesRegex(LtiException, "Missing state param"):
             self._launch(launch_request, tool_conf)
 
         launch_request = self._get_request(
-            login_request, login_response, empty_cookies=True
+            login_request=login_request, login_response=login_response, empty_cookies=True
         )
         with self.assertRaisesRegex(LtiException, "State not found"):
             self._launch(launch_request, tool_conf)
@@ -251,7 +252,7 @@ class ResourceLinkBase(TestLinkBase):
         post_data["id_token"] += ".absjdbasdj"
 
         launch_request = self._get_request(
-            login_request, login_response, post_data=post_data
+            login_request=login_request, login_response=login_response, post_data=post_data
         )
         with self.assertRaisesRegex(LtiException, "Invalid id_token"):
             self._launch(launch_request, tool_conf)
@@ -260,7 +261,7 @@ class ResourceLinkBase(TestLinkBase):
         post_data["id_token"] = "jbafjjsdbjasdabsjdbasdj1212121212.sdfhdhsf.sdfdsfdsf"
 
         launch_request = self._get_request(
-            login_request, login_response, post_data=post_data
+            login_request=login_request, login_response=login_response, post_data=post_data
         )
         with self.assertRaisesRegex(LtiException, "Invalid JWT format"):
             self._launch(launch_request, tool_conf)
@@ -272,7 +273,7 @@ class ResourceLinkBase(TestLinkBase):
         post_data["id_token"] += "jbafjjsdbjasdabsjdbasdj"
 
         launch_request = self._get_request(
-            login_request, login_response, post_data=post_data
+            login_request=login_request, login_response=login_response, post_data=post_data
         )
         with self.assertRaisesRegex(LtiException, "Can't decode id_token"):
             self._launch(launch_request, tool_conf)
@@ -309,7 +310,7 @@ class ResourceLinkBase(TestLinkBase):
 
         post_data = self.post_launch_data.copy()
         launch_request = self._get_request(
-            login_request, login_response, post_data=post_data
+            login_request=login_request, login_response=login_response, post_data=post_data
         )
 
         with self.assertRaisesRegex(LtiMessageValidationException, 'The "nonce" field is empty.'):
@@ -318,7 +319,7 @@ class ResourceLinkBase(TestLinkBase):
             )
 
         launch_request = self._get_request(
-            login_request, login_response, post_data=post_data, empty_session=True
+            login_request=login_request, login_response=login_response, post_data=post_data, empty_session=True
         )
 
         with self.assertRaisesRegex(LtiException, "Invalid Nonce"):
@@ -329,7 +330,7 @@ class ResourceLinkBase(TestLinkBase):
 
         post_data = self.post_launch_data.copy()
         launch_request = self._get_request(
-            login_request, login_response, post_data=post_data
+            login_request=login_request, login_response=login_response, post_data=post_data
         )
 
         with self.assertRaisesRegex(
@@ -344,7 +345,7 @@ class ResourceLinkBase(TestLinkBase):
 
         post_data = self.post_launch_data.copy()
         launch_request = self._get_request(
-            login_request, login_response, post_data=post_data
+            login_request=login_request, login_response=login_response, post_data=post_data
         )
 
         with self.assertRaisesRegex(
@@ -360,7 +361,7 @@ class ResourceLinkBase(TestLinkBase):
 
         post_data = self.post_launch_data.copy()
         launch_request = self._get_request(
-            login_request, login_response, post_data=post_data
+            login_request=login_request, login_response=login_response, post_data=post_data
         )
 
         with self.assertRaisesRegex(LtiException, "Incorrect version"):
@@ -370,8 +371,8 @@ class ResourceLinkBase(TestLinkBase):
 
 
 class TestDjangoResourceLink(DjangoMixin, ResourceLinkBase):
-    pass
+    __test__ = True
 
 
 class TestFlaskResourceLink(FlaskMixin, ResourceLinkBase):
-    pass
+    __test__ = True

--- a/tests/test_submission_review_launch.py
+++ b/tests/test_submission_review_launch.py
@@ -4,6 +4,7 @@ from .flask_mixin import FlaskMixin
 
 
 class SubmissionReviewLaunchBase(TestLinkBase):
+    __test__ = False
     # pylint: disable=abstract-method,no-member
 
     iss = "https://canvas.instructure.com"
@@ -126,7 +127,7 @@ class SubmissionReviewLaunchBase(TestLinkBase):
 
     def test_submission_review_launch_success(self):
         tool_conf, login_request, login_response = self._make_oidc_login()
-        launch_request = self._get_request(login_request, login_response)
+        launch_request = self._get_request(login_request=login_request, login_response=login_response)
         validated_message_launch = self._launch(
             launch_request, tool_conf, force_validation=True
         )
@@ -142,8 +143,8 @@ class SubmissionReviewLaunchBase(TestLinkBase):
 
 
 class TestDjangoSubmissionReviewLaunch(DjangoMixin, SubmissionReviewLaunchBase):
-    pass
+    __test__ = True
 
 
 class TestFlaskSubmissionReviewLaunch(FlaskMixin, SubmissionReviewLaunchBase):
-    pass
+    __test__ = True


### PR DESCRIPTION
## Summary
- Add `__test__ = False` on all abstract base test classes (`DeepLinkBase`,
  `PrivacyLaunchBase`, `ResourceLinkBase`, `SubmissionReviewLaunchBase`) to
  prevent pytest from collecting them directly, since they are incomplete
  without their mixins
- Add `__test__ = True` on concrete subclasses to restore collection after
  inheriting `False` from the base
- Fix all `_get_request()` calls in test files to use keyword arguments,
  matching `DjangoMixin`'s keyword-only signature
- Add `conftest.py` to configure a minimal Django in-memory cache, fixing
  `ImproperlyConfigured` errors in `test_grades.py`
- Fix missing `TemplateDoesNotExist` import in `OIDCLogin`

## Known issue
`TestDjangoResourceLink::test_res_link_check_cookies_page` is still failing
due to a missing Django template for the cookie check page. I  will try to
fix it in a separate branch.