### PR TITLE
add unit tests for models 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import django
 from django.conf import settings
 
 

--- a/tests/test_deep_link_resource.py
+++ b/tests/test_deep_link_resource.py
@@ -1,0 +1,101 @@
+from pylti1p3.lineitem import LineItem
+from pylti1p3.deep_link_resource import DeepLinkResource
+import unittest
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+
+class TestDeepLinkResourceDefaults(unittest.TestCase):
+    def test_default_type_is_lti_resource_link(self):
+        self.assertEqual(DeepLinkResource().get_type(), "ltiResourceLink")
+
+    def test_default_target_is_iframe(self):
+        self.assertEqual(DeepLinkResource().get_target(), "iframe")
+
+    def test_defaults_are_none(self):
+        r = DeepLinkResource()
+        self.assertIsNone(r.get_title())
+        self.assertIsNone(r.get_url())
+        self.assertIsNone(r.get_lineitem())
+        self.assertIsNone(r.get_icon_url())
+
+    def test_default_custom_params_is_empty(self):
+        self.assertEqual(DeepLinkResource().get_custom_params(), {})
+
+
+class TestDeepLinkResourceFluentSetters(unittest.TestCase):
+    def test_set_title_returns_self(self):
+        r = DeepLinkResource()
+        self.assertIs(r.set_title("My Tool"), r)
+
+    def test_chaining(self):
+        r = (
+            DeepLinkResource()
+            .set_title("Quiz")
+            .set_url("https://tool.example.com/quiz/1")
+            .set_target("window")
+        )
+        self.assertEqual(r.get_title(), "Quiz")
+        self.assertEqual(r.get_url(), "https://tool.example.com/quiz/1")
+        self.assertEqual(r.get_target(), "window")
+
+
+class TestDeepLinkResourceToDict(unittest.TestCase):
+    def test_to_dict_minimal(self):
+        r = DeepLinkResource().set_title("T").set_url("https://example.com")
+        d = r.to_dict()
+        self.assertEqual(d["type"], "ltiResourceLink")
+        self.assertEqual(d["title"], "T")
+        self.assertEqual(d["url"], "https://example.com")
+        self.assertNotIn("lineItem", d)
+        self.assertNotIn("icon", d)
+        self.assertNotIn("custom", d)
+
+    def test_to_dict_with_icon_url(self):
+        r = DeepLinkResource().set_icon_url("https://example.com/icon.png")
+        d = r.to_dict()
+        self.assertEqual(d["icon"], {"url": "https://example.com/icon.png"})
+
+    def test_to_dict_with_custom_params(self):
+        r = DeepLinkResource().set_custom_params({"chapter": "3"})
+        d = r.to_dict()
+        self.assertEqual(d["custom"], {"chapter": "3"})
+
+    def test_to_dict_with_lineitem_score_maximum_only(self):
+        li = LineItem().set_score_maximum(100)
+        r = DeepLinkResource().set_lineitem(li)
+        d = r.to_dict()
+        self.assertIn("lineItem", d)
+        self.assertEqual(d["lineItem"]["scoreMaximum"], 100)
+        self.assertNotIn("label", d["lineItem"])
+        self.assertNotIn("tag", d["lineItem"])
+
+    def test_to_dict_with_lineitem_full(self):
+        li = (
+            LineItem()
+            .set_score_maximum(50)
+            .set_label("Score")
+            .set_tag("quiz")
+            .set_resource_id("res-001")
+        )
+        r = DeepLinkResource().set_lineitem(li)
+        d = r.to_dict()
+        li_dict = d["lineItem"]
+        self.assertEqual(li_dict["scoreMaximum"], 50)
+        self.assertEqual(li_dict["label"], "Score")
+        self.assertEqual(li_dict["tag"], "quiz")
+        self.assertEqual(li_dict["resourceId"], "res-001")
+
+    def test_to_dict_with_lineitem_submission_review(self):
+        li = LineItem().set_score_maximum(10)
+        li.set_submission_review(["Completed"], label="Review")
+        r = DeepLinkResource().set_lineitem(li)
+        d = r.to_dict()
+        self.assertIn("submissionReview", d["lineItem"])
+        self.assertEqual(d["lineItem"]["submissionReview"]["label"], "Review")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_grade_model.py
+++ b/tests/test_grade_model.py
@@ -1,0 +1,95 @@
+import json
+import unittest
+from datetime import datetime
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from pylti1p3.grade import Grade
+from pylti1p3.exception import LtiException
+
+
+class TestGradeModel(unittest.TestCase):
+    def test_fluent_setters_return_self(self):
+        g = Grade()
+        result = g.set_score_given(80).set_score_maximum(100).set_user_id("u1")
+        self.assertIs(result, g)
+
+    def test_score_given_valid(self):
+        g = Grade().set_score_given(75.5)
+        self.assertEqual(g.get_score_given(), 75.5)
+
+    def test_score_given_zero_is_valid(self):
+        g = Grade().set_score_given(0)
+        self.assertEqual(g.get_score_given(), 0)
+
+    def test_score_given_negative_raises(self):
+        with self.assertRaises(LtiException):
+            Grade().set_score_given(-1)
+
+    def test_score_given_non_numeric_raises(self):
+        with self.assertRaises(LtiException):
+            Grade().set_score_given("high")
+
+    def test_score_maximum_valid(self):
+        g = Grade().set_score_maximum(100)
+        self.assertEqual(g.get_score_maximum(), 100)
+
+    def test_score_maximum_negative_raises(self):
+        with self.assertRaises(LtiException):
+            Grade().set_score_maximum(-5)
+
+    def test_timestamp_from_string(self):
+        g = Grade().set_timestamp("2024-01-15T10:00:00+00:00")
+        self.assertEqual(g.get_timestamp(), "2024-01-15T10:00:00+00:00")
+
+    def test_timestamp_from_datetime(self):
+        dt = datetime(2024, 6, 1, 12, 0, 0)
+        g = Grade().set_timestamp(dt)
+        self.assertEqual(g.get_timestamp(), "2024-06-01T12:00:00")
+
+    def test_get_value_excludes_none_fields(self):
+        g = Grade().set_score_given(80).set_score_maximum(100).set_user_id("u1")
+        data = json.loads(g.get_value())
+        self.assertEqual(data["scoreGiven"], 80)
+        self.assertEqual(data["scoreMaximum"], 100)
+        self.assertEqual(data["userId"], "u1")
+        self.assertNotIn("comment", data)
+        self.assertNotIn("timestamp", data)
+
+    def test_get_value_includes_submission_when_started_at_set(self):
+        g = Grade().set_started_at("2024-01-01T09:00:00")
+        data = json.loads(g.get_value())
+        self.assertIn("submission", data)
+        self.assertEqual(data["submission"]["startedAt"], "2024-01-01T09:00:00")
+
+    def test_get_value_includes_submission_when_submitted_at_set(self):
+        g = Grade().set_submitted_at("2024-01-01T10:00:00")
+        data = json.loads(g.get_value())
+        self.assertIn("submission", data)
+        self.assertEqual(data["submission"]["submittedAt"], "2024-01-01T10:00:00")
+
+    def test_get_value_no_submission_when_neither_set(self):
+        g = Grade().set_score_given(50).set_score_maximum(100)
+        data = json.loads(g.get_value())
+        self.assertNotIn("submission", data)
+
+    def test_extra_claims_merged_in_get_value(self):
+        g = Grade().set_score_given(10).set_score_maximum(20)
+        g.set_extra_claims({"customField": "customValue"})
+        data = json.loads(g.get_value())
+        self.assertEqual(data["customField"], "customValue")
+
+    def test_comment(self):
+        g = Grade().set_comment("Well done!")
+        self.assertEqual(g.get_comment(), "Well done!")
+
+    def test_activity_and_grading_progress(self):
+        g = Grade().set_activity_progress("Completed").set_grading_progress("FullyGraded")
+        self.assertEqual(g.get_activity_progress(), "Completed")
+        self.assertEqual(g.get_grading_progress(), "FullyGraded")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lineitem_model.py
+++ b/tests/test_lineitem_model.py
@@ -1,0 +1,116 @@
+from pylti1p3.exception import LineItemException
+from pylti1p3.lineitem import LineItem
+import json
+import unittest
+
+
+class TestLineItemInit(unittest.TestCase):
+    def test_empty_init(self):
+        li = LineItem()
+        self.assertIsNone(li.get_id())
+        self.assertIsNone(li.get_label())
+        self.assertIsNone(li.get_score_maximum())
+        self.assertIsNone(li.get_tag())
+
+    def test_init_from_dict(self):
+        li = LineItem({
+            "id": "http://lms.example.com/lineitems/1",
+            "scoreMaximum": 100,
+            "label": "Final Exam",
+            "tag": "exam",
+            "resourceId": "res-001",
+            "resourceLinkId": "link-001",
+        })
+        self.assertEqual(li.get_id(), "http://lms.example.com/lineitems/1")
+        self.assertEqual(li.get_score_maximum(), 100)
+        self.assertEqual(li.get_label(), "Final Exam")
+        self.assertEqual(li.get_tag(), "exam")
+        self.assertEqual(li.get_resource_id(), "res-001")
+        self.assertEqual(li.get_resource_link_id(), "link-001")
+
+
+class TestLineItemSetters(unittest.TestCase):
+    def test_fluent_setters_return_self(self):
+        li = LineItem()
+        result = li.set_label("Quiz").set_score_maximum(50).set_tag("quiz")
+        self.assertIs(result, li)
+
+    def test_score_maximum_valid(self):
+        li = LineItem().set_score_maximum(100)
+        self.assertEqual(li.get_score_maximum(), 100)
+
+    def test_score_maximum_zero_raises(self):
+        with self.assertRaises(LineItemException):
+            LineItem().set_score_maximum(0)
+
+    def test_score_maximum_negative_raises(self):
+        with self.assertRaises(LineItemException):
+            LineItem().set_score_maximum(-10)
+
+    def test_score_maximum_non_numeric_raises(self):
+        with self.assertRaises(LineItemException):
+            LineItem().set_score_maximum("high")
+
+    def test_datetime_fields(self):
+        li = LineItem().set_start_date_time("2024-01-01T00:00:00Z")
+        li.set_end_date_time("2024-12-31T23:59:59Z")
+        self.assertEqual(li.get_start_date_time(), "2024-01-01T00:00:00Z")
+        self.assertEqual(li.get_end_date_time(), "2024-12-31T23:59:59Z")
+
+
+class TestLineItemSubmissionReview(unittest.TestCase):
+    def test_set_submission_review_minimal(self):
+        li = LineItem().set_score_maximum(10)
+        li.set_submission_review(["Completed"])
+        sr = li.get_submission_review()
+        self.assertEqual(sr["reviewableStatus"], ["Completed"])
+        self.assertNotIn("label", sr)
+
+    def test_set_submission_review_full(self):
+        li = LineItem().set_score_maximum(10)
+        li.set_submission_review(
+            ["Completed", "InProgress"],
+            label="Review here",
+            url="https://tool.example.com/review",
+            custom={"key": "val"},
+        )
+        sr = li.get_submission_review()
+        self.assertEqual(sr["label"], "Review here")
+        self.assertEqual(sr["url"], "https://tool.example.com/review")
+        self.assertEqual(sr["custom"], {"key": "val"})
+
+    def test_set_submission_review_invalid_status_raises(self):
+        li = LineItem().set_score_maximum(10)
+        with self.assertRaises(LineItemException):
+            li.set_submission_review("Completed")
+
+
+class TestLineItemGetValue(unittest.TestCase):
+    def test_get_value_excludes_empty_fields(self):
+        li = LineItem().set_score_maximum(50).set_label("Score")
+        data = json.loads(li.get_value())
+        self.assertEqual(data["scoreMaximum"], 50)
+        self.assertEqual(data["label"], "Score")
+        self.assertNotIn("id", data)
+        self.assertNotIn("tag", data)
+
+    def test_get_value_with_all_fields(self):
+        li = (
+            LineItem()
+            .set_id("http://lms.example.com/lineitems/42")
+            .set_score_maximum(100)
+            .set_label("Midterm")
+            .set_tag("midterm")
+            .set_resource_id("r1")
+            .set_resource_link_id("rl1")
+            .set_start_date_time("2024-03-01T00:00:00Z")
+            .set_end_date_time("2024-03-02T00:00:00Z")
+        )
+        data = json.loads(li.get_value())
+        self.assertEqual(data["id"], "http://lms.example.com/lineitems/42")
+        self.assertEqual(data["tag"], "midterm")
+        self.assertEqual(data["startDateTime"], "2024-03-01T00:00:00Z")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -1,0 +1,112 @@
+from pylti1p3.registration import Registration
+import unittest
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+
+PUBLIC_KEY = """-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAuvEnCaUOy1l9gk3wjW3P
+ib1dBc5g92+6rhvZZOsN1a77fdOqKsrjWG1lDu8kq2nL+wbAzR3DdEPVw/1WUwtr
+/Q1d5m+7S4ciXT63pENs1EPwWmeN33O0zkGx8I7vdiOTSVoywEyUZe6UyS+ujLfs
+Rc2ImeLP5OHxpE1yULEDSiMLtSvgzEaMvf2AkVq5EL5nLYDWXZWXUnpiT/f7iK47
+Mp2iQd4KYYG7YZ7lMMPCMBuhej7SOtZQ2FwaBjvZiXDZ172sQYBCiBAmOR3ofTL6
+aD2+HUxYztVIPCkhyO84mQ7W4BFsOnKW4WRfEySHXd2hZkFMgcFNXY3dA6de519q
+lcrL0YYx8ZHpzNt0foEzUsgJd8uJMUVvzPZgExwcyIbv5jWYBg0ILgULo7ve7VXG
+5lMwasW/ch2zKp7tTILnDJwITMjF71h4fn4dMTun/7MWEtSl/iFiALnIL/4/YY71
+7cr4rmcG1424LyxJGRD9L9WjO8etAbPkiRFJUd5fmfqjHkO6fPxyWsMUAu8bfYdV
+RH7qN/erfGHmykmVGgH8AfK9GLT/cjN4GHA29bK9jMed6SWdrkygbQmlnsCAHrw0
+RA+QE0t617h3uTrSEr5vkbLz+KThVEBfH84qsweqcac/unKIZ0e2iRuyVnG4cbq8
+HUdio8gJ62D3wZ0UvVgr4a0CAwEAAQ==
+-----END PUBLIC KEY-----
+"""
+
+
+class TestRegistrationModel(unittest.TestCase):
+    def test_defaults_are_none(self):
+        r = Registration()
+        self.assertIsNone(r.get_issuer())
+        self.assertIsNone(r.get_client_id())
+        self.assertIsNone(r.get_key_set_url())
+        self.assertIsNone(r.get_auth_token_url())
+        self.assertIsNone(r.get_auth_login_url())
+        self.assertIsNone(r.get_tool_private_key())
+
+    def test_fluent_setters_return_self(self):
+        r = Registration()
+        result = (
+            r.set_issuer("https://platform.example.com")
+            .set_client_id("client-abc")
+            .set_auth_token_url("https://platform.example.com/token")
+        )
+        self.assertIs(result, r)
+
+    def test_setters_and_getters(self):
+        r = (
+            Registration()
+            .set_issuer("https://platform.example.com")
+            .set_client_id("client-abc")
+            .set_key_set_url("https://platform.example.com/jwks")
+            .set_auth_token_url("https://platform.example.com/token")
+            .set_auth_login_url("https://platform.example.com/auth")
+            .set_auth_audience("https://platform.example.com")
+        )
+        self.assertEqual(r.get_issuer(), "https://platform.example.com")
+        self.assertEqual(r.get_client_id(), "client-abc")
+        self.assertEqual(r.get_key_set_url(), "https://platform.example.com/jwks")
+        self.assertEqual(r.get_auth_token_url(), "https://platform.example.com/token")
+        self.assertEqual(r.get_auth_login_url(), "https://platform.example.com/auth")
+        self.assertEqual(r.get_auth_audience(), "https://platform.example.com")
+
+    def test_set_key_set_none(self):
+        r = Registration().set_key_set(None)
+        self.assertIsNone(r.get_key_set())
+
+    def test_set_key_set_dict(self):
+        ks = {"keys": [{"kty": "RSA", "kid": "k1", "alg": "RS256"}]}
+        r = Registration().set_key_set(ks)
+        self.assertEqual(r.get_key_set(), ks)
+
+
+class TestRegistrationGetJwk(unittest.TestCase):
+    def test_get_jwk_returns_rsa_key(self):
+        jwk = Registration.get_jwk(PUBLIC_KEY)
+        self.assertEqual(jwk["kty"], "RSA")
+
+    def test_get_jwk_sets_alg_rs256(self):
+        jwk = Registration.get_jwk(PUBLIC_KEY)
+        self.assertEqual(jwk["alg"], "RS256")
+
+    def test_get_jwk_sets_use_sig(self):
+        jwk = Registration.get_jwk(PUBLIC_KEY)
+        self.assertEqual(jwk["use"], "sig")
+
+    def test_get_jwk_contains_kid(self):
+        jwk = Registration.get_jwk(PUBLIC_KEY)
+        self.assertIn("kid", jwk)
+        self.assertIsInstance(jwk["kid"], str)
+
+    def test_get_jwks_with_public_key(self):
+        r = Registration().set_tool_public_key(PUBLIC_KEY)
+        keys = r.get_jwks()
+        self.assertEqual(len(keys), 1)
+        self.assertEqual(keys[0]["kty"], "RSA")
+
+    def test_get_jwks_without_public_key_returns_empty(self):
+        r = Registration()
+        self.assertEqual(r.get_jwks(), [])
+
+    def test_get_kid_with_public_key(self):
+        r = Registration().set_tool_public_key(PUBLIC_KEY)
+        kid = r.get_kid()
+        self.assertIsNotNone(kid)
+        self.assertIsInstance(kid, str)
+
+    def test_get_kid_without_public_key_returns_none(self):
+        r = Registration()
+        self.assertIsNone(r.get_kid())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,0 +1,122 @@
+import unittest
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from pylti1p3.roles import (
+    StudentRole, TeacherRole, StaffRole,
+    TeachingAssistantRole, DesignerRole, ObserverRole, TransientRole,
+)
+
+MEMBERSHIP = "http://purl.imsglobal.org/vocab/lis/v2/membership#{}"
+INSTITUTION = "http://purl.imsglobal.org/vocab/lis/v2/institution/person#{}"
+SYSTEM = "http://purl.imsglobal.org/vocab/lis/v2/system/person#{}"
+ROLES_CLAIM = "https://purl.imsglobal.org/spec/lti/claim/roles"
+
+
+def jwt_body(*role_urns):
+    return {ROLES_CLAIM: list(role_urns)}
+
+
+class TestStudentRole(unittest.TestCase):
+    def test_context_learner_is_student(self):
+        self.assertTrue(StudentRole(jwt_body(MEMBERSHIP.format("Learner"))).check())
+
+    def test_context_member_is_student(self):
+        self.assertTrue(StudentRole(jwt_body(MEMBERSHIP.format("Member"))).check())
+
+    def test_institution_student_is_student(self):
+        self.assertTrue(StudentRole(jwt_body(INSTITUTION.format("Student"))).check())
+
+    def test_institution_prospective_student_is_student(self):
+        self.assertTrue(StudentRole(jwt_body(INSTITUTION.format("ProspectiveStudent"))).check())
+
+    def test_teacher_context_role_is_not_student(self):
+        self.assertFalse(StudentRole(jwt_body(MEMBERSHIP.format("Instructor"))).check())
+
+    def test_empty_roles_returns_false(self):
+        self.assertFalse(StudentRole(jwt_body()).check())
+
+
+class TestTeacherRole(unittest.TestCase):
+    def test_context_instructor_is_teacher(self):
+        self.assertTrue(TeacherRole(jwt_body(MEMBERSHIP.format("Instructor"))).check())
+
+    def test_context_administrator_is_teacher(self):
+        self.assertTrue(TeacherRole(jwt_body(MEMBERSHIP.format("Administrator"))).check())
+
+    def test_student_context_role_is_not_teacher(self):
+        self.assertFalse(TeacherRole(jwt_body(MEMBERSHIP.format("Learner"))).check())
+
+
+class TestStaffRole(unittest.TestCase):
+    def test_institution_instructor_is_staff(self):
+        self.assertTrue(StaffRole(jwt_body(INSTITUTION.format("Instructor"))).check())
+
+    def test_system_administrator_is_staff(self):
+        self.assertTrue(StaffRole(jwt_body(SYSTEM.format("Administrator"))).check())
+
+    def test_institution_faculty_is_staff(self):
+        self.assertTrue(StaffRole(jwt_body(INSTITUTION.format("Faculty"))).check())
+
+    def test_student_is_not_staff(self):
+        self.assertFalse(StaffRole(jwt_body(MEMBERSHIP.format("Learner"))).check())
+
+
+class TestContextRolesPrecedence(unittest.TestCase):
+    """PR #13 — context roles take priority over institution/system roles."""
+
+    def test_institution_instructor_with_context_learner_is_not_teacher(self):
+        # Canvas sends institution Instructor even when the user is a student in this course.
+        body = jwt_body(
+            INSTITUTION.format("Instructor"),
+            MEMBERSHIP.format("Learner"),
+        )
+        self.assertFalse(TeacherRole(body).check())
+
+    def test_institution_instructor_with_context_learner_is_student(self):
+        body = jwt_body(
+            INSTITUTION.format("Instructor"),
+            MEMBERSHIP.format("Learner"),
+        )
+        self.assertTrue(StudentRole(body).check())
+
+    def test_without_context_roles_institution_instructor_is_teacher(self):
+        # When there are no context roles, institution roles are checked normally.
+        body = jwt_body(INSTITUTION.format("Instructor"))
+        self.assertFalse(TeacherRole(body).check())  # TeacherRole has no institution roles
+
+    def test_staff_institution_without_context_roles(self):
+        body = jwt_body(INSTITUTION.format("Instructor"))
+        self.assertTrue(StaffRole(body).check())
+
+
+class TestOtherRoles(unittest.TestCase):
+    def test_teaching_assistant(self):
+        self.assertTrue(
+            TeachingAssistantRole(jwt_body(MEMBERSHIP.format("TeachingAssistant"))).check()
+        )
+
+    def test_designer(self):
+        self.assertTrue(
+            DesignerRole(jwt_body(MEMBERSHIP.format("ContentDeveloper"))).check()
+        )
+
+    def test_observer(self):
+        self.assertTrue(
+            ObserverRole(jwt_body(MEMBERSHIP.format("Mentor"))).check()
+        )
+
+    def test_transient(self):
+        self.assertTrue(
+            TransientRole(jwt_body(MEMBERSHIP.format("Transient"))).check()
+        )
+
+    def test_unknown_role_string_returns_false(self):
+        body = jwt_body("urn:some-unknown-role")
+        self.assertFalse(StudentRole(body).check())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add unit tests for `Registration` model — setters, getters, JWK generation
- Add unit tests for `LineItem` model — validation, serialization, submission review
- Add unit tests for `DeepLinkResource` model — defaults, `to_dict()`, lineitem integration
- Add unit tests for `Grade` model — score validation, timestamp, serialization
- Add unit tests for `roles` — all role types, context roles precedence over institution roles