### PR TITLE
fix: Django cookie check falls back to NotImplementedError when templ…

### DIFF
--- a/src/pylti1p3/contrib/django/oidc_login.py
+++ b/src/pylti1p3/contrib/django/oidc_login.py
@@ -2,6 +2,7 @@ import typing as t
 from django.http import HttpResponse, HttpRequest  # type: ignore
 from django.shortcuts import render
 from django.template.exceptions import TemplateDoesNotExist
+from pylti1p3.cookies_allowed_check import CookiesAllowedCheckPage
 from pylti1p3.oidc_login import OIDCLogin
 
 from .cookie import DjangoCookieService
@@ -67,4 +68,11 @@ class DjangoOIDCLogin(
                 },
             )
         except TemplateDoesNotExist:
-            return super().get_cookies_allowed_js_check()
+            html = CookiesAllowedCheckPage(
+                params=params,
+                protocol=protocol,
+                main_text=self._cookies_unavailable_msg_main_text,
+                click_text=self._cookies_unavailable_msg_click_text,
+                loading_text=self._cookies_check_loading_text,
+            ).get_html()
+            return self.get_response(html)

--- a/tests/django_mixin.py
+++ b/tests/django_mixin.py
@@ -79,9 +79,7 @@ class DjangoMixin:
                 launch_url = "http://lti.django.test/launch/"
 
                 if enable_check_cookies:
-                    response_html = oidc_login.enable_check_cookies().redirect(
-                        launch_url
-                    )
+                    response_html = oidc_login.enable_check_cookies().redirect(launch_url)
                     self.assertTrue('<script type="text/javascript">' in response_html)
                     self.assertTrue("<body>" in response_html)
                     self.assertTrue(


### PR DESCRIPTION
When enable_check_cookies() is called in a Django project that does not have the pylti1p3/cookies_allowed_js_check.html template configured, DjangoOIDCLogin.get_cookies_allowed_js_check() catches TemplateDoesNotExist and calls super().get_cookies_allowed_js_check(). However, the base class raises NotImplementedError, causing the application to crash instead of displaying the cookie check page.

The library already provides CookiesAllowedCheckPage, a Python class that generates the cookie check HTML without requiring any template. It was used nowhere in the Django contrib.