### PR TITLE
fix: serialize deployment_ids as JSON in dynamic registration

### DIFF
--- a/src/pylti1p3/contrib/django/lti1p3_tool_config/dynamic_registration.py
+++ b/src/pylti1p3/contrib/django/lti1p3_tool_config/dynamic_registration.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Dict
 
 from django.urls import reverse_lazy
@@ -90,7 +91,7 @@ class DjangoDynamicRegistration(DynamicRegistration):
                 "auth_audience": openid_configuration["token_endpoint"],
                 "key_set_url": openid_configuration["jwks_uri"],
                 "tool_key": tool_key,
-                "deployment_ids": deployment_ids,
+                "deployment_ids": json.dumps(deployment_ids),
             },
         )
 


### PR DESCRIPTION
Title: fix: serialize deployment_ids as JSON in dynamic registration

## My analysis

During dynamic registration, complete_registration() in DjangoDynamicRegistration passes a Python list directly to the deployment_ids field of LtiTool. Since this field is a TextField, Django serializes it using str(), which produces "['3']" (single quotes) instead of '["3"]' (double quotes). This is invalid JSON.

When the tool later reads this field, DjangoDbToolConf calls json.loads(lti_tool.deployment_ids), which raises a JSONDecodeError and crashes the launch. 
