### PR TITLE
Remove scale attr from readme images

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,17 +4,14 @@ LTI 1.3 Advantage Tool implementation in Python
 This is a fork of the `pylti1p3 <https://github.com/dmitry-viskov/pylti1.3>`_ package, originally written by Dmitry Viskov.
 
 .. image:: https://img.shields.io/pypi/v/pylti1p3next
-    :scale: 100%
     :target: https://pypi.python.org/pypi/pylti1p3next
     :alt: PyPI
 
 .. image:: https://img.shields.io/pypi/pyversions/pylti1p3next
-    :scale: 100%
     :target: https://www.python.org/
     :alt: Python
 
 .. image:: https://img.shields.io/github/license/pymsglobal/pylti1p3next
-    :scale: 100%
     :target: https://raw.githubusercontent.com/pymsglobal/pylti1p3next/master/LICENSE
     :alt: MIT
 


### PR DESCRIPTION
This attribute is breaking `twine check` and is unnecessary.