### PR TITLE
fix: relax pyjwt pin to allow 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ classifiers = [
 ]
 dependencies = [
     "jwcrypto~=1.5",
-    "pyjwt~=1.5",
+    "pyjwt>=1.5",
     "requests~=2.32",
     "typing_extensions~=4.2",
 ]


### PR DESCRIPTION
The current pin `pyjwt~=1.5` excludes PyJWT 2.x, but the only jwt usage in the lib `jwt.decode(..., algorithms=[...], options=...)` and `jwt.InvalidTokenError` in `message_launch.py` has identical semantics on 1.x and 2.x. The pin also makes the lib uninstallable on Python 3.13. 