### PR TITLE
fix: ServiceConnector._scope_key omits client_id which could cause an access-token cache collision across registrations sharing an issuer

### DIFF
--- a/src/pylti1p3/service_connector.py
+++ b/src/pylti1p3/service_connector.py
@@ -44,9 +44,19 @@ class ServiceConnector:
             self._requests_session.headers["User-Agent"] = REQUESTS_USER_AGENT
 
     def _scope_key(self, scopes: t.Iterable[str]) -> str:
+        """
+        A single issuer can register several client_ids, and the access token is created per
+        client_id. Including client_id here keeps the token cache from serving one client's token
+        to another when they share an issuer and request the same scopes.
+
+        See: https://www.imsglobal.org/spec/lti/v1p3#client_id-login-parameter
+        """
         issuer = self._registration.get_issuer()
+        client_id = self._registration.get_client_id()
         scopes_str: str = "|".join(
-            ([issuer] if issuer is not None else []) + sorted(scopes)
+            ([issuer] if issuer is not None else [])
+            + ([client_id] if client_id is not None else [])
+            + sorted(scopes)
         )
         scopes_bytes = scopes_str.encode("utf-8")
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,6 +4,7 @@ from .test_deep_link import TestDjangoDeepLink, TestFlaskDeepLink
 from .test_grades import TestGrades
 from .test_names_roles import TestNamesRolesProvisioningService
 from .test_resource_link import TestDjangoResourceLink, TestFlaskResourceLink
+from .test_service_connector import TestScopeKey
 from .test_tool_conf import TestToolConf
 from .test_privacy_launch import TestDjangoPrivacyLaunch, TestFlaskPrivacyLaunch
 from .test_submission_review_launch import (

--- a/tests/test_service_connector.py
+++ b/tests/test_service_connector.py
@@ -1,0 +1,32 @@
+# pylint: disable=protected-access
+import unittest
+
+from pylti1p3.registration import Registration
+from pylti1p3.service_connector import ServiceConnector
+
+SCOPES = [
+    "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
+    "https://purl.imsglobal.org/spec/lti-ags/scope/score",
+]
+
+
+def _connector(issuer, client_id):
+    registration = Registration().set_issuer(issuer).set_client_id(client_id)
+    return ServiceConnector(registration)
+
+
+class TestScopeKey(unittest.TestCase):
+    def test_scope_key_differs_by_client_id(self):
+        issuer = "https://platform.test"
+        first = _connector(issuer, "client-a")._scope_key(SCOPES)
+        second = _connector(issuer, "client-b")._scope_key(SCOPES)
+        self.assertNotEqual(first, second)
+
+    def test_scope_key_differs_by_issuer(self):
+        first = _connector("https://platform.test", "client-a")._scope_key(SCOPES)
+        second = _connector("https://other.test", "client-a")._scope_key(SCOPES)
+        self.assertNotEqual(first, second)
+
+    def test_scope_key_is_stable_for_the_same_registration(self):
+        connector = _connector("https://platform.test", "client-a")
+        self.assertEqual(connector._scope_key(SCOPES), connector._scope_key(SCOPES))


### PR DESCRIPTION
`ServiceConnector._scope_key` derives the access-token cache key from the issuer and scopes only:

```py
def _scope_key(self, scopes):
    issuer = self._registration.get_issuer()
    scopes_str = "|".join(([issuer] if issuer is not None else []) + sorted(scopes))
    return hashlib.md5(scopes_str.encode("utf-8")).hexdigest()
```

The client_id is not part of the key. LTI 1.3 explicitly allows a single issuer to host multiple registrations with distinct client_ids:

[LTI 1.3 core, sec. 4.1.3](https://www.imsglobal.org/spec/lti/v1p3#client_id-login-parameter):
> The new optional parameter client_id specifies the client id for the authorization server that should be used to authorize the subsequent LTI message request. This allows for a platform to support multiple registrations from a single issuer, without relying on the initiate_login_uri as a key.

[LTI 1.3 core, sec. 6.2.1](https://www.imsglobal.org/spec/lti/v1p3#deployment-id):

> A resource server, e.g., platform instance, is uniquely identified by its issuer, client_id, and deployment_id...

The access token itself is client-specific; `get_access_token` creates it via a client-credentials JWT with iss/sub = client_id. So two registrations that share an issuer and request the same scopes produce the same scope_key, and both `FlaskServiceConnector` and `DjangoServiceConnector` will serve one registration's token to the other.
